### PR TITLE
feat: include `master` or `main` branch in status output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+.config.yaml  # configuration-file for testing
 .idea/


### PR DESCRIPTION
Created on behalf of SDA SE

- [ ] documented:  No, because it's the new default and not yet configurable.
- [x] tested

### GitHub redirects when `/branches/master` or `/branches/main`
Interesting are the redirects responded from server and followed by client.
They are also logged as INFO by default, so we had to reduce log-level to WARNING.